### PR TITLE
fix to #375

### DIFF
--- a/data/log.js
+++ b/data/log.js
@@ -15,12 +15,23 @@ function initLog(log) {
 	}
 }
 
-function formatEntry(entry) { // TODO: convert to jquery style (see vault.js)
-
-	return $('<div class="logentry"><span class="logtime">[' +
-		new Date(entry.time).toUTCString() + '] </span>' +
-		'<span class="logtext">' + convertSpace(entry.text) +
-		'</span></div>');
+function formatEntry(entry) {
+		
+	var $entry = $('<div/>', { class: 'logentry' });
+	
+	$('<span/>', {
+		
+		class: 'logtime',
+		html: ('[' + new Date(entry.time).toUTCString() + '] ')
+	}).appendTo($entry);
+	
+	$('<span/>', {
+		
+		class: 'logtext',
+		html: convertSpace(entry.text)
+	}).appendTo($entry);
+	
+	return $entry;
 }
 
 function convertSpace(text) {
@@ -31,7 +42,6 @@ function convertSpace(text) {
 		return '';
 	}
 
-	// Uses 4 '&emsp;' as a Tab char
 	return text.replace(/\n/g, BR).replace(/\t/g, TAB);
 }
 


### PR DESCRIPTION
>  rewrite the log.js code to use jquery-style (like vault.js), primarily initLog() and formatEntry().

Rewritten formatEntry().
But I don't think initLog() needs to be rewritten: $.prepend() is just $.append() in a reversed order.

