### PR TITLE
Removed horizontal scrollbar from dynamic log

### DIFF
--- a/data/log.css
+++ b/data/log.css
@@ -21,6 +21,8 @@ body {
 	font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
 	color: #4C4D4C;
 	margin: 0;
+	overflow-x: hidden;
+	overflow-y: scroll;
 }
 
 * {


### PR DESCRIPTION
Dynamic log page was showing a horizontal scrollbar unless with a very wide browser width.

![screen shot 2015-07-15 at 1 27 34 am](https://cloud.githubusercontent.com/assets/2461812/8680031/3938cb20-2a91-11e5-964e-f7e92219cbc6.png)
