### PR TITLE
Better handling of #209

### DIFF
--- a/src/css/vault.css
+++ b/src/css/vault.css
@@ -308,10 +308,6 @@ div.tooltip {
 #container.lightbox{
 	transition: transform 0.5s ease 0.1s, margin 0.5s ease;
 	z-index: 1000;
-	
-	-ms-user-select: all;
-	-webkit-user-select: all;
-	-moz-user-select: all;
 }
 
 #container.dragged {
@@ -340,6 +336,10 @@ div.tooltip {
 
 .item.inspected {
 	z-index: 2000;
+	
+	-ms-user-select: all;
+	-webkit-user-select: all;
+	-moz-user-select: all;
 }
 
 /* AD */


### PR DESCRIPTION
This fix assures that only ``.item.inspected`` can be selected during lightboxMode.