### PR TITLE
Fix #224

### DIFF
--- a/src/js/adn/vault.js
+++ b/src/js/adn/vault.js
@@ -1461,9 +1461,8 @@
 
       var filtered = dateFilter(gMin, gMax);
 
-      // only create the adsets once, else filter
-      return gAdSets ? filterAdSets(filtered) :
-        (gAdSets = createAdSets(filtered));
+      centerContainer();
+      return gAdSets = createAdSets(filtered);
     }
 
     function centerContainer() {


### PR DESCRIPTION
We cannot "only create ``gAdSets `` once, else ``filterAdSets()``" in ``runFilter()`` because ``filterAdSets()`` uses ``gAdSets`` created with the latest ``MaxStartNum`` number of ads.