### PR TITLE
Ticket371dnt respect

### DIFF
--- a/src/firstrun.html
+++ b/src/firstrun.html
@@ -47,7 +47,7 @@
 
     <div class="row">
       <input type="checkbox" data-setting-name="respectDNT" data-setting-type="bool" id="dnt-exception" checked>
-      <label for="check-4">Make exception for non-tracking-ads<a href ="#" class="cost help-mark">?</a></label>
+      <label for="check-4" data-i18n="respectDNTPrompt"><a href ="#" class="cost help-mark">?</a></label>
     </div>
 
     <div class="row">

--- a/src/js/adn/firstrun.js
+++ b/src/js/adn/firstrun.js
@@ -40,6 +40,13 @@
     return switchValue('hidingAds') || switchValue('clickingAds');
   }
 
+  function changeDNTexceptions(bool){
+    changeUserSettings("disableClicksForDNT", bool);
+    changeUserSettings("disableHidingForDNT", bool);
+    // next line redundant when 'respectDNT' completely replaces by 'disableClicksForDNT' and 'disableHidingForDNT' in background.js/Settings
+    changeUserSettings("respectDNT", bool);
+  }
+
   function toggleDNTException(bool) {
     var dntInput = uDom('#dnt-exception')["nodes"][0];
     var dntInputWrapper = dntInput.parentElement;
@@ -47,7 +54,8 @@
       dntInputWrapper.style.display = "block";
       // this runs once only:
       if(!dntRespectAppeared){
-        changeUserSettings("respectDNT", true);
+        // changeUserSettings("respectDNT", true);
+        changeDNTexceptions(true);
         dntInput.checked = true;
         dntRespectAppeared = true;
       }
@@ -66,11 +74,19 @@
       uNode.prop('checked', details[uNode.attr('data-setting-name')] === true)
         .on('change', function () {
 
-          changeUserSettings(
-            this.getAttribute('data-setting-name'),
-            this.checked
-          );
+          if(this.getAttribute('data-setting-name') === "respectDNT"){
+            changeDNTexceptions(this.checked);
+          }else{
+            changeUserSettings(
+              this.getAttribute('data-setting-name'),
+              this.checked
+            );
+          }
 
+          if (!hideOrClick()) {
+            changeDNTexceptions(false);
+          }
+          
           toggleDNTException();
 
         });
@@ -84,9 +100,6 @@
     uDom('#confirm-close').on('click', function (e) {
       e.preventDefault();
       // handles #371
-      if (!hideOrClick()) {
-        changeUserSettings('respectDNT', false);
-      }
       window.open(location, '_self').close();
     });
 

--- a/src/js/adn/firstrun.js
+++ b/src/js/adn/firstrun.js
@@ -43,8 +43,6 @@
   function changeDNTexceptions(bool){
     changeUserSettings("disableClicksForDNT", bool);
     changeUserSettings("disableHidingForDNT", bool);
-    // next line redundant when 'respectDNT' completely replaces by 'disableClicksForDNT' and 'disableHidingForDNT' in background.js/Settings
-    changeUserSettings("respectDNT", bool);
   }
 
   function toggleDNTException(bool) {
@@ -54,7 +52,6 @@
       dntInputWrapper.style.display = "block";
       // this runs once only:
       if(!dntRespectAppeared){
-        // changeUserSettings("respectDNT", true);
         changeDNTexceptions(true);
         dntInput.checked = true;
         dntRespectAppeared = true;

--- a/src/js/adn/firstrun.js
+++ b/src/js/adn/firstrun.js
@@ -9,7 +9,7 @@
   /******************************************************************************/
 
   var messager = vAPI.messaging;
-
+  var dntRespectAppeared = false;
   /******************************************************************************/
   var changeUserSettings = function (name, value) {
 
@@ -41,9 +41,16 @@
   }
 
   function toggleDNTException(bool) {
-    var dntInputWrapper = uDom('#dnt-exception')["nodes"][0].parentElement;
+    var dntInput = uDom('#dnt-exception')["nodes"][0];
+    var dntInputWrapper = dntInput.parentElement;
     if (hideOrClick()) {
       dntInputWrapper.style.display = "block";
+      // this runs once only:
+      if(!dntRespectAppeared){
+        changeUserSettings("respectDNT", true);
+        dntInput.checked = true;
+        dntRespectAppeared = true;
+      }
     } else {
       dntInputWrapper.style.display = "none";
     }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -56,9 +56,8 @@ return {
         hidingAds: false,
         clickingAds: false,
         blockingMalware: false,
-        respectDNT: false,
-        disableClicksForDNT: false,
-        disableHidingForDNT: false,
+        disableHidingForDNT: true,
+        disableClickingForDNT: true,
 
         noThirdPartyCookies: false,
 
@@ -244,3 +243,4 @@ return {
 })();
 
 /******************************************************************************/
+*************************/

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -56,7 +56,7 @@ return {
         hidingAds: false,
         clickingAds: false,
         blockingMalware: false,
-        respectDNT: true,
+        respectDNT: false,
 
         noThirdPartyCookies: false,
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -57,6 +57,8 @@ return {
         clickingAds: false,
         blockingMalware: false,
         respectDNT: false,
+        disableClicksForDNT: false,
+        disableHidingForDNT: false,
 
         noThirdPartyCookies: false,
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -56,8 +56,8 @@ return {
         hidingAds: false,
         clickingAds: false,
         blockingMalware: false,
-        disableHidingForDNT: true,
-        disableClickingForDNT: true,
+        disableClicksForDNT: false,
+        disableHidingForDNT: false,
 
         noThirdPartyCookies: false,
 
@@ -243,4 +243,3 @@ return {
 })();
 
 /******************************************************************************/
-*************************/

--- a/src/options.html
+++ b/src/options.html
@@ -61,12 +61,19 @@
         <label data-i18n="noOutgoingUserAgentPrompt" for="no-outgoing-user-agent"></label>
       </li>
       <li>
-      <input id="respect-dnt" type="checkbox" data-setting-name="respectDNT" data-setting-type="bool">
-      <label data-i18n="respectDNTPrompt" for="respect-dnt"></label>
-      <a class="fa info" href="https://github.com/dhowe/AdNauseam/wiki/FAQ"
-          target="_blank">&#xf05a;</a>
-    </li>
-    </ul>
+        <input id="respect-dnt-for-hiding" type="checkbox" data-setting-name="disableClicksForDNT" data-setting-type="bool">
+          <label data-i18n="disableHidingForDNTPrompt" for="respect-dnt"></label>
+          <a class="fa info" href="https://github.com/dhowe/AdNauseam/wiki/FAQ"
+              target="_blank">&#xf05a;</a>
+        </li>
+      </ul>
+      <li>
+        <input id="respect-dnt-for-clicking" type="checkbox" data-setting-name="disableHidingForDNT" data-setting-type="bool">
+          <label data-i18n="disableClickingForDNTPrompt" for="respect-dnt"></label>
+          <a class="fa info" href="https://github.com/dhowe/AdNauseam/wiki/FAQ"
+              target="_blank">&#xf05a;</a>
+        </li>
+      </ul>
 
     <p></p>
     <!-- spacer -->

--- a/src/options.html
+++ b/src/options.html
@@ -62,17 +62,16 @@
       </li>
       <li>
         <input id="respect-dnt-for-hiding" type="checkbox" data-setting-name="disableClicksForDNT" data-setting-type="bool">
-          <label data-i18n="disableHidingForDNTPrompt" for="respect-dnt"></label>
-          <a class="fa info" href="https://github.com/dhowe/AdNauseam/wiki/FAQ"
+        <label data-i18n="disableHidingForDNTPrompt" for="respect-dnt"></label>
+        <a class="fa info" href="https://github.com/dhowe/AdNauseam/wiki/FAQ"
               target="_blank">&#xf05a;</a>
-        </li>
-      </ul>
+      </li>
       <li>
         <input id="respect-dnt-for-clicking" type="checkbox" data-setting-name="disableHidingForDNT" data-setting-type="bool">
-          <label data-i18n="disableClickingForDNTPrompt" for="respect-dnt"></label>
-          <a class="fa info" href="https://github.com/dhowe/AdNauseam/wiki/FAQ"
+        <label data-i18n="disableClickingForDNTPrompt" for="respect-dnt"></label>
+        <a class="fa info" href="https://github.com/dhowe/AdNauseam/wiki/FAQ"
               target="_blank">&#xf05a;</a>
-        </li>
+      </li>
       </ul>
 
     <p></p>


### PR DESCRIPTION
So, I am pretty sure I understood you right now, but it might also be wrong. 
Here is what I did: 
- I added disableClicksForDNT and disableHidingForDNT to background.js - in preparation of using the values for separate checkboxes in the settings panel. As for right now, I still only see one box in Settings, I kept the respectDNT in background.js, too, for now. 

- all toggles are false by default
- if user enables hiding or blocking, DNT-checkbox appears, default enabled (for now this controls all THREE values: respectDNT, disableClicksForDNT and disableHidingForDNT - respectDNT functionality can be easily dropped in line 47 in firstrun.js once the two boxes are in Settings).
- if user clicks OK or closes the tab while neither hiding or blocking are true, then the DNT-toggle is set to false (again, this affect all three DNT values).
- if user ever disables respectDNT on the firstrun page, it remains disabled, even after hiding/clicking are disabled, then reenabled (again, this affect all three DNTs).

-> the settings page has separate options (under the hiding and clicking headers respectively) for the two settings: disableHidingForDNT and disableClicksForDNT (see #202 for the design), these options can now be implemented and read the values from userSettings.

I'll attach a screenshot, too, showing some of this functionality:

![dnt_update](https://cloud.githubusercontent.com/assets/14130931/18529129/d4cbdd1c-7a99-11e6-80bd-6b0ffc76538f.jpg)


