### PR TITLE
clean branch fixed logic in firstrun, split DNT options into two

### DIFF
--- a/src/firstrun.html
+++ b/src/firstrun.html
@@ -47,7 +47,7 @@
 
     <div class="row">
       <input type="checkbox" data-setting-name="respectDNT" data-setting-type="bool" id="dnt-exception" checked>
-      <label for="check-4">Make exception for non-tracking-ads<a href ="#" class="cost help-mark">?</a></label>
+      <label for="check-4" data-i18n="respectDNTPrompt"><a href ="#" class="cost help-mark">?</a></label>
     </div>
 
     <div class="row">

--- a/src/js/adn/firstrun.js
+++ b/src/js/adn/firstrun.js
@@ -9,7 +9,7 @@
   /******************************************************************************/
 
   var messager = vAPI.messaging;
-
+  var dntRespectAppeared = false;
   /******************************************************************************/
   var changeUserSettings = function (name, value) {
 
@@ -40,10 +40,22 @@
     return switchValue('hidingAds') || switchValue('clickingAds');
   }
 
+  function changeDNTexceptions(bool){
+    changeUserSettings("disableClickingForDNT", bool);
+    changeUserSettings("disableHidingForDNT", bool);
+  }
+
   function toggleDNTException(bool) {
-    var dntInputWrapper = uDom('#dnt-exception')["nodes"][0].parentElement;
+    var dntInput = uDom('#dnt-exception')["nodes"][0];
+    var dntInputWrapper = dntInput.parentElement;
     if (hideOrClick()) {
       dntInputWrapper.style.display = "block";
+      // this runs once only:
+      if(!dntRespectAppeared){
+        changeDNTexceptions(true);
+        dntInput.checked = true;
+        dntRespectAppeared = true;
+      }
     } else {
       dntInputWrapper.style.display = "none";
     }
@@ -59,10 +71,18 @@
       uNode.prop('checked', details[uNode.attr('data-setting-name')] === true)
         .on('change', function () {
 
-          changeUserSettings(
-            this.getAttribute('data-setting-name'),
-            this.checked
-          );
+          if(this.getAttribute('data-setting-name') === "respectDNT"){
+            changeDNTexceptions(this.checked);
+          }else{
+            changeUserSettings(
+              this.getAttribute('data-setting-name'),
+              this.checked
+            );
+          }
+
+          if (!hideOrClick()) {
+            changeDNTexceptions(false);
+          }
 
           toggleDNTException();
 
@@ -77,9 +97,6 @@
     uDom('#confirm-close').on('click', function (e) {
       e.preventDefault();
       // handles #371
-      if (!hideOrClick()) {
-        changeUserSettings('respectDNT', false);
-      }
       window.open(location, '_self').close();
     });
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -56,8 +56,8 @@ return {
         hidingAds: false,
         clickingAds: false,
         blockingMalware: false,
-        disableHidingForDNT: true,
-        disableClickingForDNT: true,
+        disableHidingForDNT: false,
+        disableClickingForDNT: false,
 
         noThirdPartyCookies: false,
 

--- a/src/options.html
+++ b/src/options.html
@@ -60,12 +60,24 @@
             data-setting-type="bool">
         <label data-i18n="noOutgoingUserAgentPrompt" for="no-outgoing-user-agent"></label>
       </li>
-      <li>
+      <!-- <li>
       <input id="respect-dnt" type="checkbox" data-setting-name="respectDNT" data-setting-type="bool">
       <label data-i18n="respectDNTPrompt" for="respect-dnt"></label>
       <a class="fa info" href="https://github.com/dhowe/AdNauseam/wiki/FAQ"
           target="_blank">&#xf05a;</a>
-    </li>
+    </li> -->
+      <li>
+        <input id="respect-dnt-for-hiding" type="checkbox" data-setting-name="disableHidingForDNT" data-setting-type="bool">
+        <label data-i18n="disableHidingForDNTPrompt" for="respect-dnt"></label>
+        <a class="fa info" href="https://github.com/dhowe/AdNauseam/wiki/FAQ"
+              target="_blank">&#xf05a;</a>
+      </li>
+      <li>
+        <input id="respect-dnt-for-clicking" type="checkbox" data-setting-name="disableClickingForDNT" data-setting-type="bool">
+        <label data-i18n="disableClickingForDNTPrompt" for="respect-dnt"></label>
+        <a class="fa info" href="https://github.com/dhowe/AdNauseam/wiki/FAQ"
+              target="_blank">&#xf05a;</a>
+      </li>
     </ul>
 
     <p></p>


### PR DESCRIPTION
clean branch of the following changes:
**options.html**
split DNT option into two
**background.js**
DNTrespect options replaces by disableHidingForDNT and disableClickingForDNT
**firstrun.html**
replaces previously hardcoded DNT checkbox description by locales tag
**firstrun.js**
- all false by default
- DNT checkbox appears when click or hide is first click and is then enabled
- after that user can change DNT, it will not change, unless both Hide and Click are true, then it will always be false
- DNT checkbox affects both the disableHidingForDNT and the disableClickingForDNT setting at once
