### PR TITLE
Add export-ads buttons to vault #157

### DIFF
--- a/src/js/adn/options.js
+++ b/src/js/adn/options.js
@@ -12,105 +12,6 @@
 
   /******************************************************************************/
 
-  function handleImportFilePicker(evt) {
-
-    var files = evt.target.files;
-    var reader = new FileReader();
-
-    reader.onload = function (e) {
-
-      var adData;
-      try {
-        adData = JSON.parse(e.target.result);
-      }
-      catch(e){
-        postImportAlert({ count: -1, error: e });
-        return;
-      }
-
-      messager.send('adnauseam', {
-        what: 'importAds',
-        data: adData,
-        file: files[0].name
-      }, postImportAlert);
-    }
-
-    reader.readAsText(files[0]);
-  }
-
-  var postImportAlert = function (msg) {
-    var text = msg.count > -1 ? msg.count : msg.error;
-    vAPI.alert(vAPI.i18n('adnImportAlert')
-      .replace('{{count}}', text));
-  };
-
-  var startImportFilePicker = function () {
-
-    var input = document.getElementById('importFilePicker');
-    // Reset to empty string, this will ensure an change event is properly
-    // triggered if the user pick a file, even if it is the same as the last
-    // one picked.
-    input.value = '';
-    input.click();
-  };
-
-  var exportToFile = function () {
-
-    messager.send('adnauseam', {
-      what: 'exportAds',
-      filename: getExportFileName()
-    }, onLocalDataReceived);
-  };
-
-  var onLocalDataReceived = function (details) {
-
-    uDom('#localData > ul > li:nth-of-type(1)').text(
-      vAPI.i18n('settingsStorageUsed').replace('{{value}}', details.storageUsed.toLocaleString())
-    );
-
-    var elem, dt;
-    var timeOptions = {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
-      timeZoneName: 'short'
-    };
-    var lastBackupFile = details.lastBackupFile || '';
-    if (lastBackupFile !== '') {
-      dt = new Date(details.lastBackupTime);
-      uDom('#localData > ul > li:nth-of-type(2) > ul > li:nth-of-type(1)').text(dt.toLocaleString('fullwide', timeOptions));
-      //uDom('#localData > ul > li:nth-of-type(2) > ul > li:nth-of-type(2)').text(lastBackupFile);
-      uDom('#localData > ul > li:nth-of-type(2)').css('display', '');
-    }
-
-    var lastRestoreFile = details.lastRestoreFile || '';
-    elem = uDom('#localData > p:nth-of-type(3)');
-    if (lastRestoreFile !== '') {
-      dt = new Date(details.lastRestoreTime);
-      uDom('#localData > ul > li:nth-of-type(3) > ul > li:nth-of-type(1)').text(dt.toLocaleString('fullwide', timeOptions));
-      uDom('#localData > ul > li:nth-of-type(3) > ul > li:nth-of-type(2)').text(lastRestoreFile);
-      uDom('#localData > ul > li:nth-of-type(3)').css('display', '');
-    }
-  };
-
-  /******************************************************************************/
-
-  var clearAds = function () {
-
-    var msg = vAPI.i18n('adnClearConfirm');
-    var proceed = vAPI.confirm(msg);
-    if (proceed) {
-      messager.send('adnauseam', {
-        what: 'clearAds'
-      });
-    }
-  };
-
-  /******************************************************************************/
-
   var resetUserData = function() {
       var msg = vAPI.i18n('aboutResetDataConfirm').replace(/uBlock₀/g, 'AdNauseam');
       var proceed = vAPI.confirm(msg);
@@ -171,10 +72,7 @@
         .on('change', onInputChanged);
     });
 
-    uDom('#export').on('click', exportToFile);
-    uDom('#import').on('click', startImportFilePicker);
-    uDom('#importFilePicker').on('change', handleImportFilePicker);
-    uDom('#reset').on('click', clearAds);
+
     uDom('#resetOptions').on('click', resetUserData);
     uDom('#confirm-close').on('click', function (e) {
       e.preventDefault();

--- a/src/vault.html
+++ b/src/vault.html
@@ -33,10 +33,12 @@
         </div>
 
         <div id="actions">
-            <button class="button small" id="" data-l10n-id="" data-tip="" data-i18n="adnExport">Export</button>
-            <button class="button small" id="" data-l10n-id="" data-tip="" data-i18n="adnImport">Import</button>
-            <button class="button small" id="" data-l10n-id="" data-tip="" data-i18n="adnClear">Clear</button>
+            <button class="button small" id="export" data-l10n-id="" data-tip="" data-i18n="adnExport">Export</button>
+            <button class="button small" id="import" data-l10n-id="" data-tip="" data-i18n="adnImport">Import</button>
+            <input id="importFilePicker" type="file" accept="application/json" class="hiddenFileInput">
+            <button class="button small" id="reset" data-l10n-id="" data-tip="" data-i18n="adnClear">Clear</button>
         </div>
+
 
         <div id="alert" class="hide">
             <img src="img/alert.png" alt="alert">


### PR DESCRIPTION
Export, Import and Clear Ads now functional in both options.html and vault.html.
For that I took a large part of code out of options.js and into shared.js instead. 
Two things I noticed: 
(1) After clearing Ads, vault.html will always be closed. While that made sense before (when options.html was the only place to Clear), it might seem abrupt now, when Clearing in vault. I think this could changed in core.js line 897 if I understand correctly. Let me know if that should be changed. 
(2) If that all is good, then mushon (or I?) would need to go over the css for vault.html again. I had to add an input tag on line 38 to make the import button work. It's invisible, but threw off the layout slightly (shifted the buttons to the left). 