### PR TITLE
Import button works again #157

### DIFF
--- a/src/js/adn/shared.js
+++ b/src/js/adn/shared.js
@@ -193,7 +193,7 @@ function handleImportFilePicker(evt) {
       return;
     }
 
-    messager.send('adnauseam', {
+    vAPI.messaging.send('adnauseam', {
       what: 'importAds',
       data: adData,
       file: files[0].name


### PR DESCRIPTION
I took over the 'messager' variable from the options.js file in which this code was before. Replacing it with 'vAPI.messaging' in line 196 fixed the bug. I guess this still part of #157