### PR TITLE
slider in vault interfering with dragging vault

### DIFF
--- a/src/js/adn/vault.js
+++ b/src/js/adn/vault.js
@@ -1421,7 +1421,7 @@
     function runFilter(ext) {
 
       //log('vault.js::runFilter: '+ext[0]+","+ext[1]);
-
+      centerContainer();
       gMin = ext[0], gMax = ext[1];
 
       if (gAdSets != null && gAds.length !== 1 && gMax - gMin <= 1) {
@@ -1432,13 +1432,13 @@
 
       var filtered = dateFilter(gMin, gMax);
 
-      centerContainer();
+      
       return gAdSets && gAds.length < MaxStartNum ? filterAdSets(filtered) :
         (gAdSets = createAdSets(filtered));
     }
 
     function centerContainer() {
-
+      console.log("centering");
       $('#container').addClass('notransition')
         .css({
           marginLeft: '-5000px',

--- a/src/js/adn/vault.js
+++ b/src/js/adn/vault.js
@@ -1438,7 +1438,7 @@
     }
 
     function centerContainer() {
-      console.log("centering");
+
       $('#container').addClass('notransition')
         .css({
           marginLeft: '-5000px',


### PR DESCRIPTION
https://github.com/dhowe/AdNauseam/issues/459 Before my change, the Ads were centered after using the slider filter, but only if the filter had any effect. As a result of that, if the filter did not have effect (hiding/adding ads of different time periods), then the dragging of the slider would be confused with the dragging of the ad vault. 

My fix is to always center the ads after the slider is used. 

Another option would be to use a boolean to detect if the slider is currently used and deactivate the vault dragging function if that boolean is true. 