### PR TITLE
fixed to #474

### DIFF
--- a/assets/ublock/adnauseam.txt
+++ b/assets/ublock/adnauseam.txt
@@ -129,3 +129,6 @@ creativebloq.com##iframe[width="160px"][height="600px"]
 ##DIV[id*='MAXI_CRZ']
 ##DIV[id*='ucfad']
 ##DIV[id*='movie_ad']
+
+#computerworld.com
+computerworld.com###superadunit


### PR DESCRIPTION
hiding black overlay on computerworld.com page https://github.com/dhowe/AdNauseam/issues/474

the overlay only should up every time after clearing browsing data for me, so that's how to test this fix. 