### PR TITLE
button layout in whitelist: option 2

### DIFF
--- a/src/css/whitelist.css
+++ b/src/css/whitelist.css
@@ -7,11 +7,49 @@ div > p:last-child {
 #whitelist {
     box-sizing: border-box;
     font-size: small;
-    height: 60vh;
-	text-align: left;
+    height: 45vh;
+    text-align: left;
     white-space: pre;
     width: 100%;
     }
 #whitelist.bad {
     background-color: #fee;
+    }
+
+#lists {
+    padding-left: 0px;
+    /*next line for space between two sections*/
+    margin-bottom: 10vh;
+}
+
+#lists > .groupEntry > .geName {
+    font-size: 170%;
+}
+
+#lists > .groupEntry > .geCount {
+    font-size: 120%;
+}
+
+#lists > .groupEntry > .geName:before {
+    content: "";
+}
+
+#lists > .groupEntry > ul{
+    margin: 0.9em 0 0 0;
+}
+
+li.listEntry{
+    margin-left: 1.8em;
+}
+/*#whitelistApply{
+    float:right;
+}*/
+#buttonsTopRight {
+    display: initial;
+    position: fixed;
+    right: 1em;
+    z-index: 10;
+    }
+#buttonsTopRight.disabled {
+    display: none;
     }

--- a/src/js/whitelist.js
+++ b/src/js/whitelist.js
@@ -42,9 +42,11 @@ var whitelistChanged = function() {
     var s = textarea.value.trim();
     var changed = s === cachedWhitelist;
     var bad = reUnwantedChars.test(s);
-    uDom.nodeFromId('whitelistApply').disabled = changed || bad;
-    uDom.nodeFromId('whitelistRevert').disabled = changed;
     textarea.classList.toggle('bad', bad);
+
+    if(s != cachedWhitelist) uDom('#buttonsTopRight').removeClass('disabled');
+    else uDom('#buttonsTopRight').addClass('disabled');
+
 };
 
 /******************************************************************************/

--- a/src/whitelist.html
+++ b/src/whitelist.html
@@ -10,6 +10,15 @@
 </head>
 
 <body>
+  <div id="buttonsTopRight" class="disabled">
+    <!-- <button id="buttonApply" class="important" data-i18n="3pApplyChanges"></button> -->
+    <!-- <p> -->
+      <button id="whitelistApply" class="important" type="button" data-i18n="whitelistApply"></button>&ensp;
+      <button id="whitelistRevert" class="important" type="button" data-i18n="genericRevert"></button>
+    <!-- </p> -->
+
+  </div>
+  
 
   <ul id="lists"><li class="groupEntry"><span class="geName">External Whitelists</span>
     <span class="geCount dim">(1)</span>
@@ -31,10 +40,10 @@
 <div id="cloudWidget" class="hide" data-cloud-entry="whitelistPane"></div>
 
 <p data-i18n="whitelistPrompt"></p>
-<p>
+<!-- <p>
     <button id="whitelistApply" class="custom important" type="button" disabled="true" data-i18n="whitelistApply"></button>&ensp;
     <button id="whitelistRevert" class="custom" type="button" disabled="true" data-i18n="genericRevert"></button>
-</p>
+</p> -->
 <p><textarea id="whitelist" dir="auto" spellcheck="false"></textarea></p>
 <p>
     <button id="importWhitelistFromFile" class="custom" data-i18n="whitelistImport"></button>&ensp;


### PR DESCRIPTION
this regards https://github.com/dhowe/AdNauseam/issues/436 and follows @mushon 's suggestion from https://github.com/dhowe/AdNauseam/pull/484 "I suggest we float it to the right, like we do it in the 3rd party filters tab (and show both buttons only after a change was made):"

![1](https://cloud.githubusercontent.com/assets/14130931/19133048/65e0988e-8b24-11e6-9ad7-8b3b74df9cd5.png)

![2](https://cloud.githubusercontent.com/assets/14130931/19133053/68a9bbcc-8b24-11e6-8778-c08b8cfb2835.png)

