### PR TITLE
525 - solution 1

### DIFF
--- a/src/js/dashboard.js
+++ b/src/js/dashboard.js
@@ -108,6 +108,7 @@
     window.addEventListener('resize', resizeFrame);
     uDom('.tabButton').on('click', onTabClickHandler);
     uDom('#notifications').on('click', resizeFrame);
+    window.addEventListener('popstate', loadDashboardPanel);
 
      vAPI.messaging.send(
         'adnauseam', {


### PR DESCRIPTION
https://github.com/dhowe/AdNauseam/issues/525 
**scenario:** 
user opens dashboard
clicks on whitelist
opens new non-adn tab
click menu > settings
the *old* dashboard (chrome-)tab goes active again, but actually changes to the settings (dashboard-)tab (away from the before selected whiteboard tab). 
