### PR TITLE
525 - solution 2

### DIFF
--- a/src/js/dashboard.js
+++ b/src/js/dashboard.js
@@ -63,10 +63,9 @@
       url = url.slice(0, pos);
     }
     url += this.hash;
-    if (url !== window.location.href) {
-      window.location.replace(url);
-      loadDashboardPanel();
-    }
+    window.location.replace(url);
+    loadDashboardPanel();
+      
     e.preventDefault();
   };
 


### PR DESCRIPTION
https://github.com/dhowe/AdNauseam/issues/525 
**scenario:** 
user opens dashboard
clicks on whitelist
opens new non-adn tab
click menu > settings
the *old* dashboard (chrome-)tab goes active again, the whiteboard (dashboard-)tab is still open, but now the user can actually click on 'Settings'
