### PR TITLE
verifyAdBlocker update

### DIFF
--- a/platform/chromium/vapi-background.js
+++ b/platform/chromium/vapi-background.js
@@ -1478,19 +1478,34 @@ vAPI.cloud = (function() {
 /******************************************************************************/
 /******************************************************************************/
 
+vAPI.getAddonInfo = function(callback) {
+    var UBlockConflict = false,
+        AdBlockPlusConflict = false;
 
-vAPI.getAdBlockersID = function(callback) {
+    chrome.management.getAll(function(extensions) {
 
-    var uBlockId = "cjpalhdlnbpafiamejdnhcphjbkeiagm";
-    var adBlockPlusId = "cfhdojbkjhnklbpkdaibdccddilifddb";
-   
-    if (navigator.userAgent.indexOf(' OPR/') >= 0) {
-      uBlockId = "kccohkcpppjjkkjppopfnflnebibpida";
-      adBlockPlusId = "oidhhegpmlfpoeialbgcdocjalghfpkp";
-    }
+        if (chrome.runtime.lastError) {
+            //
+        } else {
 
-    return [uBlockId, adBlockPlusId];
-};
+            extensions.forEach(function(extension) {
+                if (extension.name === "Adblock Plus" && extension.enabled) {
+                    AdBlockPlusConflict = true;
+
+                } else if (extension.name === "uBlock Origin" && extension.enabled) {
+                    UBlockConflict = true;
+                }
+
+            });
+
+            callback(UBlockConflict, AdBlockPlusConflict);
+
+        }
+
+    });
+
+}
+
 
 })();
 

--- a/platform/chromium/vapi-background.js
+++ b/platform/chromium/vapi-background.js
@@ -1489,10 +1489,11 @@ vAPI.getAddonInfo = function(callback) {
         } else {
 
             extensions.forEach(function(extension) {
+                // console.log(extension.name);
                 if (extension.name === "Adblock Plus" && extension.enabled) {
                     AdBlockPlusConflict = true;
 
-                } else if (extension.name === "uBlock Origin" && extension.enabled) {
+                } else if (extension.name.startsWith("uBlock") && extension.enabled) {
                     UBlockConflict = true;
                 }
 

--- a/platform/chromium/vapi-client.js
+++ b/platform/chromium/vapi-client.js
@@ -163,27 +163,19 @@ vAPI.shutdown = (function() {
 
 /******************************************************************************/
 
-vAPI.openBrowserPage = function(URL) {
-  //update the tab if the page is already opened.
-  chrome.tabs.query({ currentWindow: true }, function(tabs) {
-
-      for (var i = 0; i < tabs.length; i++) {
-
-          if (tabs[i].url && (tabs[i].url.indexOf(URL) != -1)) {
-              chrome.tabs.update(tabs[i].id, { url: URL, selected: true });
-              return;
-          }
-      }
-
-      //if not, create a new one.
-      chrome.tabs.create({ 'url': URL });
-  });
-
-}
-
 vAPI.openExtensionsPage = function() {
-    vAPI.openBrowserPage('chrome://extensions/');
+    vAPI.messaging.send(
+        'default', {
+            what: 'gotoURL',
+            details: {
+                url: "chrome://extensions/",
+                select: true,
+                index: -1
+            }
+        }
+    )
 }
+
 /******************************************************************************/
 
 vAPI.messaging = {

--- a/platform/chromium/vapi-client.js
+++ b/platform/chromium/vapi-client.js
@@ -181,6 +181,9 @@ vAPI.openBrowserPage = function(URL) {
 
 }
 
+vAPI.openExtensionsPage = function() {
+    vAPI.openBrowserPage('chrome://extensions/');
+}
 /******************************************************************************/
 
 vAPI.messaging = {

--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -3773,7 +3773,7 @@ vAPI.getAddonInfo = function(callback) {
 
         addons.forEach(function(addon) {
             // console.log(addon.name, addon.isActive, addon.userDisabled);
-            if(addon.name == "uBlock" && addon.isActive)  UBlockConflict = true;
+            if(addon.name.startsWith("uBlock") && addon.isActive)  UBlockConflict = true;
             if(addon.name == "Adblock Plus" && addon.isActive) AdBlockPlusConflict = true;
                
         });

--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -3774,7 +3774,7 @@ vAPI.getAddonInfo = function(callback) {
         addons.forEach(function(addon) {
             // console.log(addon.name, addon.isActive, addon.userDisabled);
             if(addon.name.startsWith("uBlock") && addon.isActive)  UBlockConflict = true;
-            if(addon.name == "Adblock Plus" && addon.isActive) AdBlockPlusConflict = true;
+            if(addon.name === "Adblock Plus" && addon.isActive) AdBlockPlusConflict = true;
                
         });
         

--- a/platform/firefox/vapi-background.js
+++ b/platform/firefox/vapi-background.js
@@ -3763,6 +3763,27 @@ vAPI.cloud = (function() {
 /******************************************************************************/
 /******************************************************************************/
 
+vAPI.getAddonInfo = function(callback) {
+    var UBlockConflict = false,
+    AdBlockPlusConflict = false;
+
+    Components.utils.import("resource://gre/modules/AddonManager.jsm");
+
+    AddonManager.getAllAddons(function(addons) {
+
+        addons.forEach(function(addon) {
+            // console.log(addon.name, addon.isActive, addon.userDisabled);
+            if(addon.name == "uBlock" && addon.isActive)  UBlockConflict = true;
+            if(addon.name == "Adblock Plus" && addon.isActive) AdBlockPlusConflict = true;
+               
+        });
+        
+        callback(UBlockConflict, AdBlockPlusConflict);
+
+    });
+
+}
+
 })();
 
 /******************************************************************************/

--- a/platform/firefox/vapi-client.js
+++ b/platform/firefox/vapi-client.js
@@ -214,6 +214,13 @@ vAPI.shutdown = (function() {
     });
 })();*/
 
+vAPI.openBrowserPage = function(URL) {
+   //TODO, or try to use vAPI.tabs in vapi-background.js?
+}
+
+vAPI.openExtensionsPage = function() {
+    vAPI.openBrowserPage('about:addons');
+}
 /******************************************************************************/
 
 vAPI.prefs = {}; // ADN, for content-scripts

--- a/platform/firefox/vapi-client.js
+++ b/platform/firefox/vapi-client.js
@@ -214,12 +214,17 @@ vAPI.shutdown = (function() {
     });
 })();*/
 
-vAPI.openBrowserPage = function(URL) {
-   //TODO, or try to use vAPI.tabs in vapi-background.js?
-}
-
 vAPI.openExtensionsPage = function() {
-    vAPI.openBrowserPage('about:addons');
+    vAPI.messaging.send(
+        'default', {
+            what: 'gotoURL',
+            details: {
+                url: "about:addons",
+                select: true,
+                index: -1
+            }
+        }
+    )
 }
 /******************************************************************************/
 

--- a/src/_locales/de/adnauseam.json
+++ b/src/_locales/de/adnauseam.json
@@ -56,11 +56,11 @@
     "description":"English: Notifications -> Activate the EasyList filter"
   },
   "adnNotificationDisableAdBlockPlus":{
-    "message":"AdBlock Plus and AdNauseam may conflict!",
+    "message":"AdBlock Plus und AdNauseam könnten sich gegenseitig behindern!",
     "description":"English: Notifications -> AdBlock Plus and AdNauseam may conflict!"
   },
   "adnNotificationDisableUBlock":{
-    "message":"uBlock and AdNauseam may conflict!",
+    "message":"uBlock und AdNauseam könnten sich gegenseitig behindern!",
     "description":"English: Notifications -> uBlock and AdNauseam may conflict!"
   },
   "adnTarget":{

--- a/src/js/adn/core.js
+++ b/src/js/adn/core.js
@@ -1395,7 +1395,7 @@
           dirty = false;
 
       vAPI.getAddonInfo(function(UBlockConflict, AdBlockPlusConflict) {
-          console.log(UBlockConflict, AdBlockPlusConflict);
+          // console.log(UBlockConflict, AdBlockPlusConflict);
           if (AdBlockPlusConflict) {
 
               dirty = addNotification(notes, AdBlockPlusEnabled);

--- a/src/js/adn/core.js
+++ b/src/js/adn/core.js
@@ -1391,62 +1391,30 @@
    * TODO: Shall be handled differently on different browser
    */
   var verifyAdBlockers = exports.verifyAdBlockers = function() {
-  var UBlockConflict = false,
-    AdBlockPlusConflict = false,
-    notes = notifications,
-    dirty = false;
+      var notes = notifications,
+          dirty = false;
 
-  if (vAPI.chrome && chrome.management) {
-
-
-    chrome.management.getAll(function (extensions) {
-
-        if (chrome.runtime.lastError) {
-
-          //
-
-        } else {
-
-            var adblockers = vAPI.getAdBlockersID(),
-            uBlockId = adblockers[0],
-            adBlockPlusId = adblockers[1];
-
-
-          for (var i in extensions) {
-
-            var extension = extensions[i];
-
-            if (extension.id === adBlockPlusId && extension.enabled) {
-              AdBlockPlusConflict = true;
-
-            } else if (extension.id === uBlockId && extension.enabled) {
-              UBlockConflict = true;
-            }
-
-          }
-
-          // console.log(AdBlockPlusConflict,UBlockConflict);
-
+      vAPI.getAddonInfo(function(UBlockConflict, AdBlockPlusConflict) {
+          console.log(UBlockConflict, AdBlockPlusConflict);
           if (AdBlockPlusConflict) {
 
-            dirty = addNotification(notes, AdBlockPlusEnabled);
+              dirty = addNotification(notes, AdBlockPlusEnabled);
           } else {
-            dirty = removeNotification(notes, AdBlockPlusEnabled);
+              dirty = removeNotification(notes, AdBlockPlusEnabled);
           }
 
           if (UBlockConflict) {
 
-            dirty = dirty || addNotification(notes, UBlockEnabled);
+              dirty = dirty || addNotification(notes, UBlockEnabled);
           } else {
-            dirty = dirty || removeNotification(notes, UBlockEnabled);
+              dirty = dirty || removeNotification(notes, UBlockEnabled);
           }
 
           dirty && sendNotifications(notes);
-        }
 
       });
-    }
   }
+
 
   var verifySettings = exports.verifySettings = function () {
 

--- a/src/js/adn/options.js
+++ b/src/js/adn/options.js
@@ -130,7 +130,7 @@
 
   var onUserSettingsReceived = function (details) {
 
-    console.log('onUserSettingsReceived', details);
+    // console.log('onUserSettingsReceived', details);
 
     uDom('[data-setting-type="bool"]').forEach(function (uNode) {
 

--- a/src/js/adn/shared.js
+++ b/src/js/adn/shared.js
@@ -205,7 +205,7 @@ function reactivateList() {
 }
 
 function openExtPage() {
-    vAPI.openBrowserPage('chrome://extensions/');
+    vAPI.openExtensionsPage();
 }
 
 function reloadPane() {

--- a/src/js/dashboard.js
+++ b/src/js/dashboard.js
@@ -38,7 +38,7 @@
   };
 
   var loadDashboardPanel = function (notifications) {
-    console.log(notifications);
+    // console.log(notifications);
 
     var pane = window.location.hash.slice(1);
     if (pane === '') {


### PR DESCRIPTION
In the verifyAdBlocker update:
1.I Packed some of the code in core.js-> `verifyAdBlocker` to vapi-background.js in chrome;
2.Added the corresponding code for vapi-background.js in firefox;
3.Added OpenExtensionsPage for vapi-client.js in firefox and chrome. Because the url for extensions page are different.
4.Changed the openBrowserPage to openExtensPage in share.js

So now the `verifyAdBlocker` should be live in all three browsers, though there is still one thing need to be done:
Because the javascript API in Firefox can only be used in background.html, I can't write a similar openBrowserPage function in Firefox as what I did in chrome... Do you have any suggestions for this? Or is there a way to trigger the vAPI.tabs from vapi-background in content script?