### PR TITLE
fix css issue in menu

### DIFF
--- a/src/css/menu.css
+++ b/src/css/menu.css
@@ -591,6 +591,7 @@ footer {
   bottom: 0;
   position: absolute;
   width:100%;
+  z-index:2;
 }
 button.pause,
 button.resume,


### PR DESCRIPTION
ads preview image goes on top of the footer.
![screen shot 2016-12-05 at 3 53 16 pm](https://cloud.githubusercontent.com/assets/3056154/20877376/34b3e13a-bb03-11e6-89bb-9786afd9a632.png)
