### PR TITLE
fix adnauseam filters reloading

### DIFF
--- a/src/js/adn/core.js
+++ b/src/js/adn/core.js
@@ -1021,7 +1021,6 @@
 
     var entry, content, pos, c, lists = [];
     
-    console.log(listEntries);
     for (var path in listEntries) {
 
       entry = listEntries[path];

--- a/src/js/adn/core.js
+++ b/src/js/adn/core.js
@@ -1020,7 +1020,8 @@
   var listsForFilter = function (compiledFilter) {
 
     var entry, content, pos, c, lists = [];
-
+    
+    console.log(listEntries);
     for (var path in listEntries) {
 
       entry = listEntries[path];
@@ -1272,11 +1273,12 @@
 
   exports.onListsLoaded = function (firstRun) {
 
-    console.log('onListsLoaded:', firstRun);
-    µb.staticFilteringReverseLookup.initWorker(function (entries) {
+    // console.log('onListsLoaded:', firstRun);
+
+     var onEntriesReady = function (entries) {
 
       listEntries = entries;
-      //console.log('listEntries:', listEntries);
+      // console.log('listEntries:', listEntries);
       var keys = Object.keys(entries);
       log("[LOAD] Compiled " + keys.length +
         " 3rd-party lists in " + (+new Date() - profiler) + "ms");
@@ -1285,7 +1287,10 @@
       verifySettings();
       verifyLists(µb.remoteBlacklists);
       µb.adnauseam.dnt.updateFilters();
-    });
+    };
+
+    //force initWorker
+    µb.staticFilteringReverseLookup.initWorker(onEntriesReady, !firstRun)
 
     if (firstRun && !isAutomated()) {
 

--- a/src/js/reverselookup.js
+++ b/src/js/reverselookup.js
@@ -60,13 +60,16 @@ var stopWorker = function() {
 
 /******************************************************************************/
 
-var initWorker = function(callback) {
+var initWorker = function(callback, force) {
+    
+    // console.log("worker",worker,"needLists",needLists);
+    
     if ( worker === null ) {
         worker = new Worker('js/reverselookup-worker.js');
         worker.onmessage = onWorkerMessage;
     }
 
-    if ( needLists === false ) {
+    if ( needLists === false && force != true) {
         callback();
         return;
     }

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -694,6 +694,9 @@
     };
 
     this.loadFilterLists(onFiltersReady);
+
+    // console.log("Reload filter lists for adnauseam");
+    µBlock.adnauseam.onListsLoaded(false);//ADN
 };
 
 /******************************************************************************/


### PR DESCRIPTION
`onListsLoaded` is getting all the entries from `µb.staticFilteringReverseLookup.initWorker`. However, `µb.staticFilteringReverseLookup.initWorker` was originally designed to be called only once when the extension starts. In this pull request, I tried to force run this function but I feel that this might not be a proper way to achieve this...

Ideally, when firstRun is false,  `onListsLoaded` should get the entries from 'getCompiledFilterLists', which should be a function that loops through all the entries selected and do µb.getCompiledFilterList. 

Please let me know you opinion on this.