### PR TITLE
hot fix for DNT FAQ

### DIFF
--- a/src/js/adn/shared.js
+++ b/src/js/adn/shared.js
@@ -155,9 +155,11 @@ function Notification(m) {
   this.prop = opt(m, 'prop', '');
   this.name = opt(m, 'name', '');
   this.text = opt(m, 'text', '');
-  this.link = opt(m, 'link', this.isDNT ? DNTFAQ : FAQ);
 
   this.isDNT = opt(m, 'isDNT', '');
+
+  this.link = opt(m, 'link', this.isDNT ? DNTFAQ : FAQ);
+
   this.listName = opt(m, 'listName', '');
   this.expected = opt(m, 'expected', true);
   this.firstrun = opt(m, 'firstrun', false);


### PR DESCRIPTION
 #1175 it looks like this.isDNT is referenced before it is assigned so it is always linked to FAQ instead of DNTFAQ. (Always false for this.isDNT?)