### PR TITLE
A slight bit of crucial maintenance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,0 @@
-# Submitting issues
-
-Submit on <https://github.com/uBlockOrigin/uBlock-issues/issues>.
-
-Issue tracker here is read-only for non-[prior contributors](https://github.com/gorhill/uBlock/graphs/contributors).

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 <!-- [![Build Status](https://travis-ci.org/dhowe/AdNauseam.svg)](https://travis-ci.org/dhowe/AdNauseam) -->
-<a href="http://www.gnu.org/licenses/gpl-3.0.en.html"><img src="https://img.shields.io/badge/license-GPL-orange.svg" alt="gpl license"></a> [![Gitter](https://badges.gitter.im/dhowe/AdNauseam.svg)](https://gitter.im/dhowe/AdNauseam?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+<a href="https://www.gnu.org/licenses/gpl-3.0.en.html"><img src="https://img.shields.io/badge/license-GPL-orange.svg" alt="gpl license"></a> [![Gitter](https://badges.gitter.im/dhowe/AdNauseam.svg)](https://gitter.im/dhowe/AdNauseam?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-Install [AdNauseam](http://adnauseam.io) for [Firefox](https://addons.mozilla.org/en-US/firefox/addon/adnauseam), [Opera](https://addons.opera.com/en/extensions/details/adnauseam-2) or [Chrome](https://github.com/dhowe/AdNauseam/wiki/Install-AdNauseam-on-Chrome-Without-Google's-P
+Install [AdNauseam](https://adnauseam.io) for [Firefox](https://addons.mozilla.org/en-US/firefox/addon/adnauseam), [Opera](https://addons.opera.com/en/extensions/details/adnauseam-2) or [Chrome](https://github.com/dhowe/AdNauseam/wiki/Install-AdNauseam-on-Chrome-Without-Google's-Permission)
 <div align="left">
-  <a href="http://adnauseam.io">
+  <a href="https://adnauseam.io">
     <img src="https://rednoise.org/images/adnauseam.png" width="150px"/>
   </a>
 </div>
 
-[AdNauseam](http://adnauseam.io) is a lightweight browser extension that blends software tool and artware intervention to actively fight back against tracking by advertising networks. AdNauseam works like an ad-blocker (it is built atop [uBlock Origin](https://github.com/gorhill/uBlock)) to silently simulate clicks on each blocked ad, confusing trackers as to one's real interests. At the same time, AdNauseam serves as a means of amplifying discontent with advertising networks that disregard privacy and enable bulk surveillance.
+[AdNauseam](https://adnauseam.io) is a lightweight browser extension that blends software tool and artware intervention to actively fight back against tracking by advertising networks. AdNauseam works like an ad-blocker (it is built atop [uBlock Origin](https://github.com/gorhill/uBlock)) to silently simulate clicks on each blocked ad, confusing trackers as to one's real interests. At the same time, AdNauseam serves as a means of amplifying discontent with advertising networks that disregard privacy and enable bulk surveillance.
 
-We conceptualize AdNauseam as a software system that serves ethical, political, and expressive ends. In light of the industry's failure to address the excesses of network tracking, AdNauseam allows individual users to take matters into their own hands, offering active defense against surveillance, profiling and potential discrimination. The software thus represents a similar approach to that of <a href="http://cs.nyu.edu/trackmenot" target="_blank">TrackMeNot</a>, relocating power in the hands of individual users, rather than vast commercial entities. For further information on this approach, please see <a href="http://cs.nyu.edu/trackmenot/resources/trackmenot2009.pdf" target="_blank">this paper</a>.
+We conceptualize AdNauseam as a software system that serves ethical, political, and expressive ends. In light of the industry's failure to address the excesses of network tracking, AdNauseam allows individual users to take matters into their own hands, offering active defense against surveillance, profiling and potential discrimination. The software thus represents a similar approach to that of <a href="https://cs.nyu.edu/trackmenot" target="_blank">TrackMeNot</a>, relocating power in the hands of individual users, rather than vast commercial entities. For further information on this approach, please see <a href="https://cs.nyu.edu/trackmenot/resources/trackmenot2009.pdf" target="_blank">this paper</a>.
 
 
 #### About the project
 --------
 
-* Web Site:         http://adnauseam.io
-* Authors:          [Daniel C. Howe](http://rednoise.org/daniel), [Helen Nissenbaum](https://www.nyu.edu/projects/nissenbaum/) and [Mushon Zer-Aviv](http://mushon.com)
-* Developers:       [Daniel C. Howe](http://rednoise.org/daniel) and [Sally Chen](https://github.com/cqx931)
+* Web Site:         https://adnauseam.io
+* Authors:          [Daniel C. Howe](https://rednoise.org/daniel), [Helen Nissenbaum](https://www.nyu.edu/projects/nissenbaum/) and [Mushon Zer-Aviv](http://mushon.com)
+* Developers:       [Daniel C. Howe](https://rednoise.org/daniel) and [Sally Chen](https://github.com/cqx931)
 * License:          GPLv3 (see included [LICENSE.txt](https://github.com/dhowe/AdNauseam/blob/master/LICENSE.txt) file for full license)
 * Github Repo:      https://github.com/dhowe/adnauseam/
 * Bug Tracker:      https://github.com/dhowe/adnauseam/issues

--- a/assets/assets.json
+++ b/assets/assets.json
@@ -319,7 +319,7 @@
 		"group": "regions",
 		"off": true,
 		"title": "BGR: Bulgarian Adblock list",
-		"lang": "bg",
+		"lang": "bg mk",
 		"contentURL": "https://stanev.org/abp/adblock_bg.txt",
 		"supportURL": "https://stanev.org/abp/"
 	},
@@ -335,6 +335,7 @@
 	"CHN-1": {
 		"content": "filters",
 		"group": "regions",
+		"off": false,
 		"title": "CHN: CJX's EasyList Lite",
 		"lang": "zh",
 		"contentURL": "https://raw.githubusercontent.com/cjx82630/cjxlist/master/cjxlist.txt",
@@ -384,17 +385,17 @@
 		"content": "filters",
 		"group": "regions",
 		"off": true,
-		"title": "FIN: Finnish Addition to Easylist",
+		"title": "FIN: Adblock List for Finland",
 		"lang": "fi",
-		"contentURL": "https://adb.juvander.net/Finland_adb.txt",
-		"supportURL": "https://www.juvander.fi/AdblockFinland"
+		"contentURL": "https://raw.githubusercontent.com/finnish-easylist-addition/finnish-easylist-addition/master/Finland_adb.txt",
+		"supportURL": "https://github.com/finnish-easylist-addition/finnish-easylist-addition"
 	},
 	"FRA-0": {
 		"content": "filters",
 		"group": "regions",
 		"off": true,
 		"title": "FRA: EasyList Liste FR",
-		"lang": "ar fr",
+		"lang": "ar br fr oc",
 		"contentURL": "https://easylist-downloads.adblockplus.org/liste_fr.txt",
 		"supportURL": "https://forums.lanik.us/viewforum.php?f=91"
 	},
@@ -413,19 +414,16 @@
 		"off": true,
 		"title": "HUN: hufilter",
 		"lang": "hu",
-		"contentURL": "https://raw.githubusercontent.com/szpeter80/hufilter/master/hufilter.txt",
-		"supportURL": "https://github.com/szpeter80/hufilter"
+		"contentURL": "https://raw.githubusercontent.com/hufilter/hufilter/master/hufilter.txt",
+		"supportURL": "https://github.com/hufilter/hufilter"
 	},
 	"IDN-0": {
 		"content": "filters",
 		"group": "regions",
 		"off": true,
-		"title": "IDN: ABPindo",
-		"lang": "id",
-		"contentURL": [
-			"https://raw.githubusercontent.com/ABPindo/indonesianadblockrules/master/subscriptions/abpindo.txt",
-			"https://raw.githubusercontent.com/heradhis/indonesianadblockrules/master/subscriptions/abpindo.txt"
-		],
+		"title": "IDN, MYS: ABPindo",
+		"lang": "id ms",
+		"contentURL": "https://raw.githubusercontent.com/ABPindo/indonesianadblockrules/master/subscriptions/abpindo.txt",
 		"supportURL": "https://github.com/ABPindo/indonesianadblockrules"
 	},
 	"IRN-0": {
@@ -434,7 +432,7 @@
 		"off": true,
 		"title": "IRN: Adblock-Iran",
 		"lang": "fa",
-		"contentURL": "https://cdn.rawgit.com/farrokhi/adblock-iran/master/filter.txt",
+		"contentURL": "https://gitcdn.xyz/repo/farrokhi/adblock-iran/master/filter.txt",
 		"supportURL": "https://github.com/farrokhi/adblock-iran"
 	},
 	"ISL-0": {
@@ -449,6 +447,7 @@
 	"ISR-0": {
 		"content": "filters",
 		"group": "regions",
+		"off": false,
 		"title": "ISR: EasyList Hebrew",
 		"lang": "he",
 		"contentURL": "https://raw.githubusercontent.com/easylist/EasyListHebrew/master/EasyListHebrew.txt",
@@ -459,7 +458,7 @@
 		"group": "regions",
 		"off": true,
 		"title": "ITA: EasyList Italy",
-		"lang": "it",
+		"lang": "it lij",
 		"contentURL": "https://easylist-downloads.adblockplus.org/easylistitaly.txt",
 		"supportURL": "https://forums.lanik.us/viewforum.php?f=96"
 	},
@@ -471,20 +470,11 @@
 		"contentURL": "https://raw.githubusercontent.com/gioxx/xfiles/master/filtri.txt",
 		"supportURL": "https://xfiles.noads.it/"
 	},
-	"JPN-0": {
-		"content": "filters",
-		"group": "regions",
-		"off": true,
-		"title": "JPN: ABP Japanese filters (日本用フィルタ)",
-		"lang": "ja",
-		"contentURL": "https://raw.githubusercontent.com/k2jp/abp-japanese-filters/master/abpjf.txt",
-		"supportURL": "https://github.com/k2jp/abp-japanese-filters/wiki/Support_Policy"
-	},
 	"JPN-1": {
 		"content": "filters",
 		"group": "regions",
 		"off": true,
-		"title": "JPN: Adguard Japan Filter",
+		"title": "JPN: AdGuard Japanese",
 		"lang": "ja",
 		"contentURL": "https://filters.adtidy.org/extension/ublock/filters/7.txt",
 		"supportURL": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters",
@@ -531,7 +521,7 @@
 		"group": "regions",
 		"off": true,
 		"title": "NLD: EasyList Dutch",
-		"lang": "nl",
+		"lang": "af fy nl",
 		"contentURL": "https://easylist-downloads.adblockplus.org/easylistdutch.txt",
 		"supportURL": "https://forums.lanik.us/viewforum.php?f=100"
 	},
@@ -539,20 +529,32 @@
 		"content": "filters",
 		"group": "regions",
 		"off": true,
-		"title": "NOR: Dandelion Sprouts norske filtre",
-		"lang": "nb",
-		"contentURL": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt",
+		"title": "NOR, DNK, ISL: Dandelion Sprouts nordiske filtre",
+		"lang": "nb nn no da is",
+		"contentURL": [
+			"https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt",
+			"https://repo.or.cz/FilterMirrorRepo.git/blob_plain/refs/heads/master:/NorwegianList.txt"
+		],
 		"supportURL": "https://github.com/DandelionSprout/adfilt"
 	},
 	"POL-0": {
 		"content": "filters",
 		"group": "regions",
 		"off": true,
-		"title": "POL: polskie filtry do Adblocka i uBlocka",
+		"title": "POL: Oficjalne Polskie Filtry do AdBlocka, uBlocka Origin i AdGuarda",
 		"lang": "pl",
 		"contentURL": "https://raw.githubusercontent.com/MajkiIT/polish-ads-filter/master/polish-adblock-filters/adblock.txt",
 		"supportURL": "https://github.com/MajkiIT/polish-ads-filter/issues",
 		"instructionURL": "https://github.com/MajkiIT/polish-ads-filter#polish-filters-for-adblock-ublock-origin--adguard"
+	},
+	"POL-2": {
+		"content": "filters",
+		"group": "regions",
+		"off": true,
+		"title": "POL: Oficjalne polskie filtry przeciwko alertom o Adblocku",
+		"lang": "pl",
+		"contentURL": "https://raw.githubusercontent.com/olegwukr/polish-privacy-filters/master/anti-adblock.txt",
+		"supportURL": "https://github.com/olegwukr/polish-privacy-filters/issues"
 	},
 	"ROU-1": {
 		"content": "filters",
@@ -571,7 +573,7 @@
 		"group": "regions",
 		"off": true,
 		"title": "RUS: RU AdList",
-		"lang": "be ru uk",
+		"lang": "be kk ru uk uz",
 		"contentURL": "https://easylist-downloads.adblockplus.org/advblock+cssfixes.txt",
 		"supportURL": "https://forums.lanik.us/viewforum.php?f=102",
 		"instructionURL": "https://forums.lanik.us/viewtopic.php?f=102&t=22512"
@@ -579,8 +581,9 @@
 	"RUS-2": {
 		"content": "filters",
 		"group": "regions",
-		"title": "RUS: Adguard Russian Filter",
-		"lang": "be ru uk",
+		"off": false,
+		"title": "RUS: AdGuard Russian",
+		"lang": "be kk ru uk uz",
 		"contentURL": "https://filters.adtidy.org/extension/ublock/filters/1.txt",
 		"supportURL": "https://forum.adguard.com/forumdisplay.php?69-%D0%A4%D0%B8%D0%BB%D1%8C%D1%82%D1%80%D1%8B-Adguard",
 		"instructionURL": "https://kb.adguard.com/ru/general/adguard-ad-filters#russian"
@@ -588,8 +591,9 @@
 	"spa-0": {
 		"content": "filters",
 		"group": "regions",
+		"off": false,
 		"title": "spa: EasyList Spanish",
-		"lang": "es",
+		"lang": "an ast ca es eu gl",
 		"contentURL": "https://easylist-downloads.adblockplus.org/easylistspanish.txt",
 		"supportURL": "https://forums.lanik.us/viewforum.php?f=103"
 	},
@@ -597,8 +601,8 @@
 		"content": "filters",
 		"group": "regions",
 		"off": true,
-		"title": "spa, por: Adguard Spanish/Portuguese",
-		"lang": "es pt",
+		"title": "spa, por: AdGuard Spanish/Portuguese",
+		"lang": "an ast ca es eu gl pt",
 		"contentURL": "https://filters.adtidy.org/extension/ublock/filters/9.txt",
 		"supportURL": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters",
 		"instructionURL": "https://kb.adguard.com/en/general/adguard-ad-filters"
@@ -634,7 +638,7 @@
 		"content": "filters",
 		"group": "regions",
 		"off": true,
-		"title": "TUR: Adguard Turkish Filter",
+		"title": "TUR: AdGuard Turkish",
 		"lang": "tr",
 		"contentURL": "https://filters.adtidy.org/extension/ublock/filters/13.txt",
 		"supportURL": "https://github.com/AdguardTeam/AdguardFilters#adguard-filters",


### PR DESCRIPTION
Greetings, Dandelion Sprout here, the maintainer of *Dandelion Sprout's Nordic Filters* and a general adblocking enthusiast.

Having learned about AdNauseam yesterday, I decided to make this pull request to see how much this extension was being worked on, and whether or not the project intended to strive for functional equivalence with uBlock Origin. What it does, is:

* Synchronised the regional lists with those of uBO.
* * Most crucially, `Finnish Addition to Easylist` should've been removed half a year ago, as it was first ousted from major adblockers due to the maintainer making blocking rules against labour union sites as a whole all of a sudden, followed by him removing all entries in his list.
* Fixed the Chrome download link in the readme.
* Changed some links in the readme from HTTP to HTTPS.
* Removed the CONTRIBUTING.md file, as it quite obviously didn't apply to the AdNauseam repo.