### PR TITLE
change in ad parsing

### DIFF
--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -319,8 +319,8 @@ stackoverflow.com#@#.adsbox
 
 # radikal.ru (video)
 radikal.ru##div[id^="DIV_DA_ADP"]
-##div[id^="advertur_"]
-##iframe[id^="advertur_"]
+radikal.ru##div[id^="advertur_"]
+radikal.ru##iframe[id^="advertur_"]
 ##iframe[src^="//octoclick.net"]
 ##img[src*="delivery.clickganic.com"]
 optoclick.net##.vjs-poster

--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -268,6 +268,9 @@ usatoday.com##DIV#module-position-8
 usatoday.com##DIV.taboola-sidebar-content
 usatoday.com##section#module-position-8
 
+# flashback.org
+flashback.org##.adcontainer
+
 # popups on kickass-top.com
 *$third-party,popup,domain=kickass-top.com
 

--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -75,9 +75,10 @@ facebook.com##.ego_unit:has(div.uiScaledImageContainer)
 facebook.com##._5hn6
 
 ##.promotion-carousel
-##*[id^="teads"]
-##*[class*="teads"]
-gizmodo.com#@#*[class*="teads"]
+
+# scmp.com
+www.scmp.com##*[id^="teads"]
+www.scmp.com##*[class*="teads"]
 
 si.com#@#.ad
 si.com#@#.mobile-ad

--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -419,6 +419,8 @@ bitcoin.treasurebits.net##iframe[src="about:blank"]
 ||images.sohu.com/bill/s2015/jscript/lib/sjs/matrix/ad/form/bigView.js^$important
 ||teads.tv^$important,third-party,domain=mingpao.com
 
+||amazon-adsystem.com^$subdocument
+
 # radikal.ru (video)
 ||laim.tv^$important,third-party
 

--- a/platform/chromium/vapi-usercss.real.js
+++ b/platform/chromium/vapi-usercss.real.js
@@ -103,12 +103,13 @@ vAPI.DOMFilterer.prototype = {
                     entry.selectors + '\n{' + entry.declarations + '}'
                 );
 
-            } 
-            // Adcheck
-            var nodes = document.querySelectorAll(entry.selectors + '');
-            for ( var node of nodes ) {
-               vAPI.adCheck && vAPI.adCheck(node);
             }
+            // AdNauseam: Duplicates?
+            // var nodes = document.querySelectorAll(entry.selectors + '');
+            // for ( var node of nodes ) {
+            //    console.log("Dom Filterer, commit now")
+            //    vAPI.adCheck && vAPI.adCheck(node);
+            // }
 
         }
 
@@ -139,11 +140,11 @@ vAPI.DOMFilterer.prototype = {
             lazy: details.lazy === true,
             injected: details.injected === true
         };
-        
+
         this.addedCSSRules.add(entry);
         this.filterset.add(entry);
 
-         // ADN adCheck
+         // ADN adCheck: core
         var nodes = document.querySelectorAll(selectorsStr);
         for ( var node of nodes ) {
             vAPI.adCheck && vAPI.adCheck(node);
@@ -199,7 +200,7 @@ vAPI.DOMFilterer.prototype = {
     hideNode: function(node) {
         if ( this.excludedNodeSet.has(node) ) { return; }
         if ( this.hideNodeAttr === undefined ) { return; }
-        
+
         node.setAttribute(this.hideNodeAttr, '');
         if ( this.hideNodeStyleSheetInjected === false ) {
             this.hideNodeStyleSheetInjected = true;

--- a/src/js/adn/parser.js
+++ b/src/js/adn/parser.js
@@ -55,6 +55,8 @@
 
     var findBgImage = function (elem) {
 
+      logP("findBgImage", elem)
+
        var attribute =  elem.style.backgroundImage ? elem.style.backgroundImage : elem.style.background;
 
        if (attribute !== undefined && clickableParent(elem)) {
@@ -326,15 +328,18 @@
         break;
 
       default: // other tag-types
+        // If element is body/html don't check children, it doens't make sense to check the whole document
+        if (elem.tagName == "BODY" || elem.tagName == "HTML") {
+          findBgImage(elem);
+          return;
+        }
 
         logP('Checking children of', elem);
         var imgs = elem.querySelectorAll('img');
         if (imgs.length) {
-
           findImageAds(imgs);
         }
         else {
-
           findBgImage(elem) || logP('No images in children of', elem);
         }
 

--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -1314,6 +1314,16 @@ vAPI.domSurveyor = (function() {
 (function bootstrap() {
 
     var bootstrapPhase2 = function(ev) {
+        // ADN
+        vAPI.domFilterer.filterset.forEach(function(c){
+          var nodes = document.querySelectorAll(c.selectors);
+          for ( var node of nodes ) {
+              // console.log("BootstrapPhase2 Adcheck:", node)
+              vAPI.adCheck && vAPI.adCheck(node);
+          }
+        //  TODO:  proceduralFilters ?
+        })
+
         // This can happen on Firefox. For instance:
         // https://github.com/gorhill/uBlock/issues/1893
         if ( window.location === null ) { return; }
@@ -1375,6 +1385,7 @@ vAPI.domSurveyor = (function() {
     };
 
     var bootstrapPhase1 = function(response) {
+
         if (response && response.prefs) vAPI.prefs = response.prefs; // ADN
         // cosmetic filtering engine aka 'cfe'
         var cfeDetails = response && response.specificCosmeticFilters;
@@ -1388,11 +1399,7 @@ vAPI.domSurveyor = (function() {
             vAPI.domFilterer = null;
             vAPI.domSurveyor = null;
         } else {
-          // ADN
-          var nodes = document.querySelectorAll(response.specificCosmeticFilters.injectedHideFilters);
-          for ( var node of nodes ) {
-              vAPI.adCheck && vAPI.adCheck(node);
-          }
+
 
             var domFilterer = vAPI.domFilterer;
             if ( response.noGenericCosmeticFiltering || cfeDetails.noDOMSurveying ) {


### PR DESCRIPTION
A few tweaks in ad parsing trying to fix many failing cases in ad collection.
Changes:
- Ad parsing in bootstrapPhase2() instead of bootstrapPhase1(), because many doms may still not loaded in bootstrapPhase1
- No children checking for HTML and BODY tags, as we don't want to scan the whole webpage for advertisements
- Remove duplicate ad check in domFilterer.commit()