### PR TITLE
Reduce frequency of storage updates

### DIFF
--- a/src/js/adn/core.js
+++ b/src/js/adn/core.js
@@ -20,6 +20,8 @@
   let lastActivity = 0;
   let lastUserActivity = 0;
   let listsLoaded = false;
+  let lastStorageUpdate = 0;
+  const updateStorageInterval = 1000 * 60 * 60; // 1h
   const notifications = [];
   const allowedExceptions = [];
   const maxAttemptsPerAd = 3;
@@ -608,9 +610,17 @@
 
   const storeUserData = function (immediate) {
 
-    // TODO: defer if we've recently written and !immediate
+    // defer if we've recently written and !immediate
+
     µb.userSettings.admap = admap;
-    vAPI.storage.set(µb.userSettings);
+    const now = millis();
+    if(immediate || (!immediate && now - lastStorageUpdate > updateStorageInterval)) {
+      vAPI.storage.set(µb.userSettings);
+      lastStorageUpdate = millis();
+    } else {
+      log("--Skip storage update--")
+    }
+
   }
 
   const validateTarget = function (ad) {

--- a/src/js/dashboard.js
+++ b/src/js/dashboard.js
@@ -136,7 +136,9 @@ vAPI.broadcastListener.add(request => {
 resizeFrame();
 
 vAPI.localStorage.getItemAsync('dashboardLastVisitedPane').then(value => {
-    loadDashboardPanel(value !== null ? value : 'options.html', true);
+    // first check current url, then local storage, then default
+    const location = window.location.hash ? window.location.hash.replace("#", "") : (value !== null ? value : 'options.html');
+    loadDashboardPanel(location, true);
 
     uDom('.tabButton').on('click', onTabClickHandler);
     uDom('#notifications').on('click', resizeFrame); //ADN

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -880,12 +880,13 @@ self.addEventListener('hiddenSettingsChanged', ( ) => {
     vAPI.storage.set({ 'availableFilterLists': filterLists });
 };
 
-µBlock.reactivateList = function(list, callback) {
+µBlock.reactivateList = function(list) {
 
   var lists = this.selectedFilterLists;
   lists.push(list);
   µBlock.selectFilterLists([{location:list, off:false}]); // change availableFilterLists
-  vAPI.storage.set({ 'selectedFilterLists': lists }, callback);
+  vAPI.storage.set({ 'selectedFilterLists': lists });
+
   µBlock.loadFilterLists();
 }
 

--- a/src/options.html
+++ b/src/options.html
@@ -135,7 +135,7 @@
         <li><input id="no-large-media" type="checkbox" data-setting-name="noLargeMedia" data-setting-type="bool"><label data-i18n="settingsNoLargeMediaPrompt" for="no-large-media"><input type="number" min="0"></label> <a class="fa info" href="https://github.com/gorhill/uBlock/wiki/Per-site-switches#no-large-media-elements" target="_blank">&#xf05a;</a>
         <li><input id="no-remote-fonts" type="checkbox" data-setting-name="noRemoteFonts" data-setting-type="bool"><label data-i18n="settingsNoRemoteFontsPrompt" for="no-remote-fonts"></label> <a class="fa info" href="https://github.com/gorhill/uBlock/wiki/Per-site-switches#no-remote-fonts" target="_blank">&#xf05a;</a>
         <li><input id="no-scripting" type="checkbox" data-setting-name="noScripting" data-setting-type="bool"><label data-i18n="settingsNoScriptingPrompt" for="no-scripting"></label> <a class="fa info" href="https://github.com/gorhill/uBlock/wiki/Per-site-switches#no-scripting" target="_blank">&#xf05a;</a>
-        <li><input id="strict-blocking" type="checkbox" data-setting-name="strictBlockingMode" data-setting-type="bool"><label data-i18n="settingsStrictBlockingMode" for="strict-blocking"></label> <a class="fa info important" href="https://github.com/dhowe/AdNauseam/wiki/Developer-FAQ#what-is-strict-blocking-mode-for-and-when-should-i-use-it" target="_blank">&#xf05a;</a></li>
+        <li><input id="strict-blocking" type="checkbox" data-setting-name="strictBlockingMode" data-setting-type="bool"><label data-i18n="settingsStrictBlockingMode" for="strict-blocking"></label> <a class="fa info important" href="https://github.com/dhowe/AdNauseam/wiki/Developer-FAQ#what-is-strict-blocking-and-when-should-i-use-it" target="_blank">&#xf05a;</a></li>
         </ul>
     </li>
 


### PR DESCRIPTION
This change is made to improve performance on https://github.com/dhowe/AdNauseam/issues/1657

By avoiding too frequent storage updates, we can reduce the CPU usage from 50-60% to 10-20% for ad clicking on large data set. (It's still way higher than the CPU usage for ad clicking with an empty AdVault : 1-2%) 

For now, I have added an storage update interval for 1 hour.  