### PR TITLE
Fix showing ads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ artifacts
 /tmp/
 misc
 artifacts/*
-
+*.DS_Store
 assets/checksums/ublock0.txt

--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -261,6 +261,8 @@ creativebloq.com##iframe[width="160px"][height="600px"]
 reuters.com#@#iframe[id^="google_ads_iframe"]
 reuters.com#@#div[id^="google_ads_iframe_"]
 reuters.com##.CanvasAd_container_sZDIL
+reuters.com##*[class^="AdSlot"]
+reuters.com##*[class^="Leaderboard__slot___VvllT"]
 ||dianomi.com^$third-party
 
 # wmoov.com


### PR DESCRIPTION
Fixing showing ads related to [issue#1733](https://github.com/dhowe/AdNauseam/issues/1733) adding the following filters for the `reuters.com` domain:

A more general filter for the `AdSlot` class pattern
`reuters.com##*[class^="AdSlot"]`

A specific one for the blank Leaderboard that keeps showing after the `AdSlot` is hidden 
`reuters.com##*[class^="Leaderboard__slot___VvllT"]`