### PR TITLE
add .adsbygoogle filter for forum2go.nl

### DIFF
--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -632,6 +632,9 @@ ninjakiwi.com##.a1scktq
 # cnbc.com
 ||ads-pd.nbcuni.com^
 
+# forum2go.nl
+forum2go.nl##.adsbygoogle
+
 ##################### Exceptions below here ########################
 
 # Requests that influence visual ads


### PR DESCRIPTION
Properly hiding ad related to [this issue](https://github.com/dhowe/AdNauseam/issues/1730)

added a domain specific rule for "forum2go.nl":
```
forum2go.nl##.adsbygoogle
```
There seemed to be an issue where the `##.adsbygoogle` rule from *Easy-List* was being overruled by the *Adn* rule `##ins[id*="aswift"] > iframe`, causing the upper `.adsbygoogle` element not being properly hidden. We should see if the same issue happens on other domains and try to come up with a more non-domain-specific solution. 
