### PR TITLE
dont adn-allow request from gmail

### DIFF
--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -635,6 +635,9 @@ ninjakiwi.com##.a1scktq
 # forum2go.nl
 forum2go.nl##.adsbygoogle
 
+# gmail fake ads
+||mail-ads.google.com/mail/u/0/ads/*$xhr,domain=mail.google.com,important
+
 ##################### Exceptions below here ########################
 
 # Requests that influence visual ads


### PR DESCRIPTION
Fixing #1746 with the exception rule to not adn-allow `mail-ads.google.com^` 

```
||mail-ads.google.com/mail/u/0/ads/*$xhr,domain=mail.google.com,important
```

