### PR TITLE
remove deprecated facebook-annoyances-blocker

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -41,14 +41,6 @@
 		],
 		"supportURL": "https://www.eff.org/dnt-policy"
 	},
-	"facebook-annoyances-blocker": {
-		"content": "filters",
-		"group": "social",
-		"title": "Facebook Annoyances Blocker",
-		"contentURL": [
-			"https://easylist-downloads.adblockplus.org/fb_annoyances_full.txt"
-		]
-	},
 	"ublock-filters": {
 		"content": "filters",
 		"group": "default",


### PR DESCRIPTION
Removing "facebook-annoyances-blocker" asset https://easylist-downloads.adblockplus.org/fb_annoyances_full.txt since it doesn't exist anymore.

It was originally added on https://github.com/dhowe/AdNauseam/commit/15339961e0432f792a68f73543e750a3f210d2e2 to fix https://github.com/dhowe/AdNauseam/issues/1588, but it persists also in uBlock, so we're closing it. 