### PR TITLE
add main.yandex ads filter

### DIFF
--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -350,6 +350,10 @@ yandex.ru##.sticky_js_inited
 yandex.ru##*[id^="fu-"]
 yandex.ru##*[class^="desktop_js_inited"]
 
+# yander email ads
+mail.yandex.ru##.mail-Layout-Content > div:has(div[style="width: 100%;"])
+
+
 # gocurrycracker.com
 ##*[id^="amzn_assoc_ad"]
 ##iframe[src*="amazon-adsystem.com"]

--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -352,7 +352,7 @@ yandex.ru##*[class^="desktop_js_inited"]
 
 # yander email ads
 mail.yandex.ru##.mail-Layout-Content > div:has(div[style="width: 100%;"])
-
+mail.yandex.ru##.ns-view-left-box > div:has(div[style="width: 100%; height: 100%;"])
 
 # gocurrycracker.com
 ##*[id^="amzn_assoc_ad"]


### PR DESCRIPTION
Fixing #1731 with the following filter:
```
mail.yandex.ru##.mail-Layout-Content > div:has(div[style="width: 100%;"])
``` 
Because of the use of [shadow-root](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM), we need to find the parent div which has `style="width: 100%;"`. This solution likely to come about again with shadow-root elements.  