### PR TITLE
#1756

### DIFF
--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -649,6 +649,9 @@ forum2go.nl##.adsbygoogle
 ##*:has(> a[href*="runative-syndicate.com"])
 ##*:has(> a[href*="run-syndicate.com"])
 
+# streamtape.com
+||in-page-push.com/400/3395407$script,domain=streamtape.com,important
+
 # gmail fake ads
 ||mail-ads.google.com/mail/u/0/ads/*$xhr,domain=mail.google.com,important
 

--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -642,6 +642,13 @@ ninjakiwi.com##.a1scktq
 # forum2go.nl
 forum2go.nl##.adsbygoogle
 
+# multiple ad elements from runative-syndicate
+##iframe[src*="runative-syndicate.com"]
+##iframe[src*="syndication.exdynsrv.com"]
+##*[id^="rn_ad_native"]
+##*:has(> a[href*="runative-syndicate.com"])
+##*:has(> a[href*="run-syndicate.com"])
+
 # gmail fake ads
 ||mail-ads.google.com/mail/u/0/ads/*$xhr,domain=mail.google.com,important
 


### PR DESCRIPTION
Fixes related to https://github.com/dhowe/AdNauseam/issues/1756

- Hide multiple ads showing from `runative-syndicate` with multiple domains such as `syndication.exdynsrv.com`, `run-syndicate.com` and `runative-syndicate.com`

- Block ads showing in `streamtape.com` streaming domain.