### PR TITLE
fix remove icon not showing for added filters

### DIFF
--- a/src/css/3p-filters.css
+++ b/src/css/3p-filters.css
@@ -105,17 +105,19 @@ body:not(.updating) .listEntry.checked.obsolete .obsolete {
 .listEntry  a.towiki {
     display: inline-block;
     }
-.listEntry  a.fa:hover, .listEntry a.fa-icon:hover {
+.listEntry  a.fa:hover, .listEntry a.fa-icon:hover, .listEntry span.fa-icon:hover {
     opacity: 1;
+    cursor: pointer;
 }
 .listEntry.support  a.support {
     display: inline-block;
 }
-.listEntry  a.remove,
-.listEntry  a.remove:visited {
-    color: darkred;
+.listEntry  .remove,
+.listEntry  .remove:visited {
+    fill: red;
+    color: red;
     }
-.listEntry.external  a.remove {
+.listEntry.external  .remove {
     display: inline-block;
     }
 .listEntry.mustread  a.mustread {


### PR DESCRIPTION
Fixing https://github.com/dhowe/AdNauseam/issues/1735

- For some reason the css classes were made for an `a` element instead of the `span`, which the element in fact was `<span class="fa-icon remove">`.
- Had to change the color from `darkred` to `red` because of the darker UI.
- fixed selector for the `:hover` style 