### PR TITLE
add adslot filter for washingtonpost.com

### DIFF
--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -469,6 +469,7 @@ horriblesubs.info##img[src*="images/b/"]
 
 # Washington Post
 www.washingtonpost.com##div[data-qa="article-body-ad"]
+www.washingtonpost.com##div.dn-hp-xs:has(wp-ad)
 
 ##################### Blocking rules ########################
 # found on wpri.com


### PR DESCRIPTION
Fixing https://github.com/dhowe/AdNauseam/issues/1851