### PR TITLE
Fixing bing.com ad collection

### DIFF
--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -285,6 +285,7 @@ g1.globo.com##.publicidade
 ##bing.com
 www.bing.com##.adbDef
 www.bing.com##.b_ad
+bing.com#@#.b_ad:remove()
 # blocking rule for anti-adblocking solutions for text ads on search page
 ||www.bing.com/rb/5j/*$script,domain=www.bing.com
 

--- a/src/js/adn/textads.js
+++ b/src/js/adn/textads.js
@@ -319,7 +319,7 @@
       const returnArr = [];
 
       while (length--) {
-        if (qa[length] === elem) {
+        if (elem.contains(qa[length]) || elem === qa[length]) { // sometimes the trigger is the parent to the query, sometimes it is the element query itself
           return true;
         }
       }
@@ -404,7 +404,6 @@
     }];
 
     const checkFilters = function (elem) {
-
       const active = filters.filter(function (f) {
         const domain = (parent !== window) ? parseDomain(document.referrer) : document.domain;
         const matched = f.domain.test(domain);
@@ -427,16 +426,20 @@
           console.log("adn: texts-ads disabled");
           return;
         }
-        const ads = checkFilters(elem);
-        if (ads) {
-
-          for (let i = 0; i < ads.length; i++) {
-            if (typeof ads[i] !== 'undefined') {
-              if (vAPI.prefs.logEvents) console.log("[PARSED] TEXT-AD", ads[i]);
-                vAPI.adParser.notifyAddon(ads[i]);
+        setTimeout(() => {
+          const ads = checkFilters(elem);
+          console.log("[PARSED] checkFilters ads", ads);
+  
+          if (ads) {
+  
+            for (let i = 0; i < ads.length; i++) {
+              if (typeof ads[i] !== 'undefined') {
+                if (vAPI.prefs.logEvents) console.log("[PARSED] TEXT-AD", ads[i]);
+                  vAPI.adParser.notifyAddon(ads[i]);
+              }
             }
           }
-        }
+        }, 2000)
       };
 
     const findGoogleTextAd = function(elem) {

--- a/src/js/adn/textads.js
+++ b/src/js/adn/textads.js
@@ -426,7 +426,7 @@
           console.log("adn: texts-ads disabled");
           return;
         }
-        setTimeout(() => {
+        // setTimeout(() => {
           const ads = checkFilters(elem);
           console.log("[PARSED] checkFilters ads", ads);
   
@@ -439,7 +439,7 @@
               }
             }
           }
-        }, 2000)
+        // }, 2000)
       };
 
     const findGoogleTextAd = function(elem) {


### PR DESCRIPTION
Fixing ad collection for bing.com.

The issue was caused by this new cosmetic uBlock action which causes the element to be removed: https://github.com/gorhill/uBlock/commit/72bb70056843024b1a31fe1ab9c90bd4e8260ba2 

There should be other cases being caused by this, which can be fixed with an exception to the cosmetic rule:
```
bing.com#@#.b_ad:remove()
```

Related to https://github.com/dhowe/AdNauseam/issues/1848