### PR TITLE
Fixing ad collection for bing.com

### DIFF
--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -285,6 +285,7 @@ g1.globo.com##.publicidade
 ##bing.com
 www.bing.com##.adbDef
 www.bing.com##.b_ad
+bing.com#@#.b_ad:remove()
 # blocking rule for anti-adblocking solutions for text ads on search page
 ||www.bing.com/rb/5j/*$script,domain=www.bing.com
 


### PR DESCRIPTION
### Fixing ad collection for bing.com https://github.com/dhowe/AdNauseam/issues/1856

The issue was caused by this new cosmetic uBlock action which causes the element to be removed: https://github.com/gorhill/uBlock/commit/72bb70056843024b1a31fe1ab9c90bd4e8260ba2 

There should be other cases being caused by this, which can be fixed with an exception to the cosmetic rule:
```
bing.com#@#.b_ad:remove()
```

Related to https://github.com/dhowe/AdNauseam/issues/1848