### PR TITLE
#1843

### DIFF
--- a/src/js/adn/parser.js
+++ b/src/js/adn/parser.js
@@ -124,6 +124,8 @@
 
       const src = img.src || img.getAttribute("src");
 
+      if (img.className === 'i-amphtml-intrinsic-sizer') return
+
       if (!src) { // no image src
 
         logP("Fail: no image src", img);
@@ -135,7 +137,7 @@
       if (!targetUrl) return;
 
       // we have an image and a click-target now
-      if (img.complete) {
+      if (img.complete || img.tagName === "AMP-IMG" ) {
 
         // process the image now
         return createImageAd(img, src, targetUrl);
@@ -330,7 +332,8 @@
         case 'IFRAME':
           elem.addEventListener('load', processIFrame, false);
           break;
-
+        
+        case 'AMP-IMG':
         case 'IMG':
           findImageAds([elem]);
           break;
@@ -344,7 +347,7 @@
 
           logP('Checking children of', elem);
 
-          const imgs = elem.querySelectorAll('img');
+          const imgs = elem.querySelectorAll('img, amp-img');
           if (imgs.length) {
             findImageAds(imgs);
           }

--- a/src/js/adn/parser.js
+++ b/src/js/adn/parser.js
@@ -124,7 +124,11 @@
 
       const src = img.src || img.getAttribute("src");
 
-      if (img.className === 'i-amphtml-intrinsic-sizer') return
+      // ignore this element which only server to generate div size. It is a transparent png image. Fixing https://github.com/dhowe/AdNauseam/issues/1843
+      if (img.className === 'i-amphtml-intrinsic-sizer') {
+        logP("Ignoring: transparent fake detection from AMP-IMG", img);
+        return;
+      }
 
       if (!src) { // no image src
 
@@ -136,7 +140,8 @@
 
       if (!targetUrl) return;
 
-      // we have an image and a click-target now
+      // we have an image and a click-target now 
+      // OR the image is from type AMP-IMG which doesn't have a "complete parameter", so we let it go through... https://github.com/dhowe/AdNauseam/issues/1843
       if (img.complete || img.tagName === "AMP-IMG" ) {
 
         // process the image now
@@ -332,7 +337,7 @@
         case 'IFRAME':
           elem.addEventListener('load', processIFrame, false);
           break;
-        
+        // support for amp-img tag 
         case 'AMP-IMG':
         case 'IMG':
           findImageAds([elem]);


### PR DESCRIPTION
Fixing https://github.com/dhowe/AdNauseam/issues/1843

These elements use `AMP-IMG` tag name, which has a "fake" transparent images which was causing our detection to miss. Also this tag doesn't have ".complete" parameter, so I let it go through without this check.

https://amp.dev/documentation/components/amp-img/