### PR TITLE
Refactor build tools to use awk instead of sed

### DIFF
--- a/tools/copy-common-files.sh
+++ b/tools/copy-common-files.sh
@@ -23,8 +23,7 @@ cp manifest.json $DES/            # use ADN manifest, not ublock's
 cp LICENSE.txt                     $DES/
 
 # ADN
-sed -i '' "s/{UBLOCK_VERSION}/${UBLOCK}/" $DES/popup.html
-sed -i '' "s/{UBLOCK_VERSION}/${UBLOCK}/" $DES/links.html
+awk -v s=$UBLOCK '{gsub(/{UBLOCK_VERSION}/, s)}1' $DES/links.html > /tmp/links.html && mv /tmp/links.html $DES/links.html
 
 # Remove the following files
 rm $DES/js/adn/tests.js

--- a/tools/make-edge.sh
+++ b/tools/make-edge.sh
@@ -21,7 +21,7 @@ cp -R $CHROMIUM/* $DES/
 # Modify manifest
 echo "*** AdNauseam.edge: Modify manifest for edge"
 # Remove "update_url"
-sed -i '' -e '/^  "update_url"/d' $DES/manifest.json
+awk '!/^  "update_url"/' $DES/manifest.json > /tmp/manifest.json && mv /tmp/manifest.json $DES/manifest.json
 
 echo "*** AdNauseam.edge: Package done."
 echo

--- a/tools/make-firefox.sh
+++ b/tools/make-firefox.sh
@@ -20,7 +20,7 @@ cp platform/firefox/vapi-webrequest.js $DES/js/
 # Webext-specific
 rm $DES/img/icon_128.png
 
-sed -i '' "s/\"{version}\"/${VERSION}/" $DES/manifest.json
+awk -v s=$VERSION '{gsub(/"{version}"/, s)}1' $DES/manifest.json > /tmp/manifest.json && mv /tmp/manifest.json $DES/manifest.json
 
 echo "*** AdNauseam.firefox: Generating meta..."
 python tools/make-firefox-meta.py $DES/

--- a/tools/make-locales.sh
+++ b/tools/make-locales.sh
@@ -46,11 +46,11 @@ do
     fi
 
     jq -s '.[0] * .[1]' $messages $adnfile > $outfile
-    sed -i '' "s/uBlock₀/AdNauseam/g" $outfile
-    sed -i '' "s/uBlock Origin/AdNauseam/g" $outfile
-    sed -i '' "s/ublock/AdNauseam/g" $outfile
-    sed -i '' "s/ ＋ / \/ /g" $outfile
-    sed -i '' "s/Ctrl+click/Alt+click/g" $outfile
+    awk '{gsub(/uBlock₀/, "AdNauseam")}1' $outfile > /tmp/outfile && mv /tmp/outfile $outfile
+    awk '{gsub(/uBlock Origin/, "AdNauseam")}1' $outfile > /tmp/outfile && mv /tmp/outfile $outfile
+    awk '{gsub(/ublock/, "AdNauseam")}1' $outfile > /tmp/outfile && mv /tmp/outfile $outfile
+    awk '{gsub(/Ctrl+click/, "Alt+click")}1' $outfile > /tmp/outfile && mv /tmp/outfile $outfile
+    awk '{gsub(/ ＋ /, " / ")}1' $outfile > /tmp/outfile && mv /tmp/outfile $outfile
   fi
 
 done

--- a/tools/make-opera.sh
+++ b/tools/make-opera.sh
@@ -43,7 +43,7 @@ rm $DES/lib/lz4/*.wat
 rm $DES/lib/publicsuffixlist/wasm/*.wasm
 rm $DES/lib/publicsuffixlist/wasm/*.wat
 
-sed -i '' "s/\"{version}\"/${VERSION}/" $DES/manifest.json  #ADN
+awk -v s=$VERSION '{gsub(/"{version}"/, s)}1' $DES/manifest.json > /tmp/manifest.json && mv /tmp/manifest.json $DES/manifest.json #ADN
 
 echo "*** AdNauseam.opera: Generating meta..."
 python tools/make-opera-meta.py $DES/


### PR DESCRIPTION
This PR makes the build tools work on linux and should work on OS X but I don't have access to a machine with OS X to confirm. The issue before was that GNU sed was different then the one on OS X.  This way should be much more portable.