### PR TITLE
fix oldEntry storage exception

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -627,7 +627,7 @@ self.addEventListener('hiddenSettingsChanged', ( ) => {
     // Convert a no longer existing stock list into an imported list.
     const customListFromStockList = assetKey => {
         const oldEntry = oldAvailableLists[assetKey];
-        if ( oldEntry === undefined || oldEntry.off === true ) { return; }
+        if ( oldEntry === undefined || oldEntry.off === true || oldEntry.contentURL === undefined) { return; } // adn #1930
         let listURL = oldEntry.contentURL;
         if ( Array.isArray(listURL) ) {
             listURL = listURL[0];


### PR DESCRIPTION
I would suggest this as a temporary fix for https://github.com/dhowe/AdNauseam/issues/1930 avoiding the exception which causes the state of the filter list to get permanently damaged.

Tested multiple times re-buidling and wasn't able to catch the exception error again. An underlying issue might still be there, but can't see any further errors at the moment. 