### PR TITLE
Change method to fetch uBlock version number

### DIFF
--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.41.0",
   "author": "Daniel C. Howe",
   "background": {
     "page": "background.html"

--- a/tools/copy-common-files.sh
+++ b/tools/copy-common-files.sh
@@ -3,7 +3,7 @@
 # This script assumes a linux environment
 
 DES=$1
-UBLOCK=`jq .version platform/chromium/manifest.json | tr -d '"'` # ADN:ublock-version
+UBLOCK=$( cat dist/version ) # ADN:ublock-version
 
 bash ./tools/make-assets.sh        $DES
 bash ./tools/make-locales.sh       $DES


### PR DESCRIPTION
Before it was getting the version value from `platform/chromium/manifest.json`, now getting the version number directly from the `dist/version` file, which seems like a cleaner solution.