### PR TITLE
unbreak willhaben.at

### DIFF
--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -8,6 +8,7 @@
 
 # Generic exceptions
 tweakers.net#@#*[class*="Advert"]
+willhaben.at#@#*[class*="Advert"]
 
 # Google map ads on Search
 google.*##.mnr-c.rl-qs-crs-t._Db > ._gt:has(._mB)


### PR DESCRIPTION
update adnauseam.txt with an exception to allow "Advert" classes on willhaben.at as this class is oddly also used on content