### PR TITLE
correct parsing of procedural filters

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.16.1.1",
+  "version": "3.16.1.2",
   "key": "ilkggpgmkemaniponkfgnkonpajankkm",
   "author": "Daniel C. Howe",
   "background": {

--- a/src/js/contentscript-extra.js
+++ b/src/js/contentscript-extra.js
@@ -495,6 +495,14 @@ class ProceduralFilterer {
             }
             if ( pselector.budget <= 0 ) { continue; }
             const nodes = pselector.exec();
+            /* ADN parse procedural selector hits */
+            if ( nodes.length > 0) {
+                console.log("[ADN] parse procedural selector hits", nodes)
+                for ( const node of nodes ) {
+                    vAPI.adCheck && vAPI.adCheck(node);
+                }
+            }
+            /* end ADN */
             const t1 = Date.now();
             pselector.budget += t0 - t1;
             if ( pselector.budget < -500 ) {

--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -682,13 +682,6 @@ vAPI.DOMFilterer = class {
                 );
             }
             for ( const json of this.convertedProceduralFilters ) {
-                /* start of Adn exception fetching */ 
-                var instance = this.proceduralFiltererInstance()
-                if (instance == null) {
-                    if (vAPI.prefs.logEvents) console.warn("[ADN] proceduralFiltererInstance null")
-                    continue;
-                }
-                /* end of Adn exception fetching */
                 out.procedural.push(
                     this.proceduralFiltererInstance().createProceduralFilter(json)
                 );
@@ -1319,22 +1312,15 @@ const bootstrapPhaseAdn = function (response) {
         }
 
 
-        // get all the selectors
-        var allSelectors = vAPI.domFilterer.getAllSelectors()
+        // get declarative selectors
+        var allSelectors = vAPI.domFilterer.getAllSelectors(0b11)
+        // 0b11 avoid getting procedural selectors, they are now handled in the contentscript-extra.js
         
-        // declarative filters
+        // parse declarative filters
         if (allSelectors.declarative && allSelectors.declarative.length > 0) {
             processFilters(allSelectors.declarative)
         }
 
-        // procedural filters
-        if (allSelectors.procedural && allSelectors.procedural.length > 0) {
-            for (var index in allSelectors.procedural) {
-                var filter = allSelectors.procedural[index]
-                if (filter.selector.length == 0) continue; 
-                processFilters(filter.selector)
-            }
-        }
         bootstrapPhaseAdnCounter++;
     }
 }


### PR DESCRIPTION
This merge correctly parses the procedural filters in the contentscript-extra.js instead, when the rules are originally being executed, therefore avoid to run the selectors again, and also parsing it the proper manner with the actions associated with each of the procedural filters.

This fixes a lot of false positives that were occurring (https://github.com/dhowe/AdNauseam/issues/2269, https://github.com/dhowe/AdNauseam/issues/2252, , since the original issue were root selectors of procedural filters being queried without their associated actions (e.g.: `has-text`, `has`, `match-upwards`, etc). Check further documentation on uBlock Origin procedural filters here https://github.com/gorhill/uBlock/wiki/Procedural-cosmetic-filters. 

Since we don't need to check the procedural filters using the `getAllSelectors` function anymore, it also solves the Null Procedural Filter Instance issue https://github.com/dhowe/AdNauseam/issues/2244.

----------

Ad collection with procedural filters should be implemented in our test sets.