### PR TITLE
remove bad filter

### DIFF
--- a/filters/adnauseam.txt
+++ b/filters/adnauseam.txt
@@ -533,9 +533,6 @@ gfp_video_ads/
 # functionalclam.com
 ||functionalclam.com^$third-party
 
-# pinterest
-pinterest.*##div:nth-of-type(2) > div:nth-of-type(2) > div
-
 # Blocking rules below here
 ||images.sohu.com/bill/s2015/jscript/lib/sjs/matrix/ad/form/bigView.js^$important
 ||teads.tv^$important,third-party,domain=mingpao.com


### PR DESCRIPTION
Fixing https://github.com/dhowe/AdNauseam/issues/2491

The following filter is too generic, removed it and ad collecting still occurs in pinterest
```
pinterest.*##div:nth-of-type(2) > div:nth-of-type(2) > div
```